### PR TITLE
Continuous builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ script:
   - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
   - mkdir appdir ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .
-  - cp ./usr/share/applications/*.desktop .
-  - cp ./usr/share/icons/hicolor/48x48/apps/*.png .
+  - cp ../*.desktop .
+  - cp ../icons/eko_icon.png eko.png
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt58base
+    - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - qmake PREFIX=/usr
+  - make -j4
+  - sudo apt-get -y install checkinstall
+  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
+  - mkdir appdir ; cd appdir
+  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cp ./usr/share/applications/*.desktop .
+  - cp ./usr/share/icons/hicolor/48x48/apps/*.png .
+  - cd .. 
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/eko -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/eko -appimage 
+  - curl --upload-file ./EKO*.AppImage https://transfer.sh/EKO-git.$(git rev-parse --short HEAD)-x86_64.AppImage 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base
+    - sudo apt-get -y install qt58base portaudio19-dev libsndfile-dev libsamplerate-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/eko.desktop
+++ b/eko.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=EKO
+GenericName=EKO Sound Editor
+Comment=Record and edit audio files
+Icon=eko
+Type=Application
+Categories=AudioVideo;Audio;AudioVideoEditing;
+Exec=eko %F
+StartupNotify=false
+Terminal=false
+MimeType=application/x-audacity-project;audio/aac;audio/ac3;audio/mp4;audio/x-ms-wma;video/mpeg;audio/flac;audio/x-flac;audio/mpeg;audio/basic;audio/x-aiff;audio/x-wav;application/ogg;audio/x-vorbis+ogg;

--- a/eko.desktop
+++ b/eko.desktop
@@ -8,4 +8,4 @@ Categories=AudioVideo;Audio;AudioVideoEditing;
 Exec=eko %F
 StartupNotify=false
 Terminal=false
-MimeType=application/x-audacity-project;audio/aac;audio/ac3;audio/mp4;audio/x-ms-wma;video/mpeg;audio/flac;audio/x-flac;audio/mpeg;audio/basic;audio/x-aiff;audio/x-wav;application/ogg;audio/x-vorbis+ogg;
+MimeType=audio/aac;audio/ac3;audio/mp4;audio/x-ms-wma;audio/flac;audio/x-flac;audio/mpeg;audio/basic;audio/x-aiff;audio/x-wav;application/ogg;audio/x-vorbis+ogg;


### PR DESCRIPTION
This PR, when merged, will compile EKO on Travis CI upon each git push, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build.

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started).

![screenshot from 2017-02-26 12-08-18](https://cloud.githubusercontent.com/assets/2480569/23339159/5b51020a-fc1c-11e6-8c71-a8e9dc17eb18.png)
Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional(!) desktop integration with `appimaged`
- Binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can GPG2-sign your AppImages (inside the file)

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

An example AppImage can be downloaded from here:
https://transfer.sh/KtSsl/eko-git.e89d36e-x86-64.appimage (available for 14 days)