### PR TITLE
Don't strip extension when saving

### DIFF
--- a/document.cpp
+++ b/document.cpp
@@ -1288,10 +1288,8 @@ bool CDocument::save_with_name (const QString &fileName)
   
 //  qDebug() << "fext:" << fext;
   
-  if (ext.isEmpty())
+  if (ext.toLower() != fext)
      fname = fname + "." + fext;
-  else
-      fname = change_file_ext (fname, fext);
 
   CTio *tio = holder->tio_handler.get_for_fname (fname);
   


### PR DESCRIPTION
I think if I enter a name like "Lesson 1.2", it should save as "Lesson 1.2.wav" not "Lesson 1.wav". Of course if the name already ends in ".wav", don't add another one.